### PR TITLE
fix: Adjust logout shortcut to trigger service to return to gaming mode

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -69,7 +69,7 @@ function _lockScreen() {
 }
 
 function _logOut() {
-	Util.spawn(['gnome-session-quit', '--logout', '--no-prompt'])
+	Util.spawn(['systemctl', 'start', 'return-to-gamemode.service'])
 }
 
 function _extensions() {


### PR DESCRIPTION
Triggers new service to return to gaming mode instead of directly logging out, allowing users to start to desktop and enter gaming mode